### PR TITLE
fix(docker): set devops key to test

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,8 @@ COPY --from=builder /app/ .
 # Default environment variables
 # App Variables
 ENV STREAMR_API_URL http://localhost:8081/streamr-core/api/v1
-ENV DEVOPS_KEY devops-user-key
+# core-api devops account private key in test db
+ENV DEVOPS_KEY 0x628acb12df34bb30a0b2f95ec2e6a743b386c5d4f63aa9f338bec6f613160e78
 ENV METRICS false
 ENV NETWORK_ID rinkeby
 ENV MARKETPLACE_ADDRESS 0xA10151D088f6f2705a05d6c83719e99E079A61C1


### PR DESCRIPTION
* Set DevOps users private key from core-api's test database