### PR TITLE
refactor: simplify getenv

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -4,8 +4,5 @@ export function getEnv(key: string): string {
     if (typeof value === "undefined") {
         return ""
     }
-    if (value === "undefined") {
-        return ""
-    }
     return value
 }

--- a/src/env_test.ts
+++ b/src/env_test.ts
@@ -6,8 +6,9 @@ describe("OS environment variables", () => {
         process.env.TEST_VAR = "hello"
         assert.equal(getEnv("TEST_VAR"), "hello")
     })
-    it("undefined variable is null", () => {
-        process.env.TEST_VAR = undefined
+    it("undefined variable returns empty string", () => {
+        delete process.env.TEST_VAR
+        assert.equal(process.env.TEST_VAR, undefined)
         assert.equal(getEnv("TEST_VAR"), "")
     })
 })


### PR DESCRIPTION
getenv does not need to check for string "undefined"